### PR TITLE
For products without a weight or digital products magento defaults to…

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -230,6 +230,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $shipAddr = $quote->getShippingAddress();
         $country = $shipAddr->getCountryId();
 
+        if(empty($country)){
+            $shipAddr = $quote->getBillingAddress();
+            $country = $shipAddr->getCountry();
+        }
+        
         if (!empty($email)) {
             if (!$quote->getCustomerEmail()) {
                 $quote->setCustomerEmail($email);


### PR DESCRIPTION
… billing address - so no shipping address would be found this led to a fail no_country