### PR TITLE
fix untranslated string

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -347,7 +347,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             return $response->url;
         } else {
             if ($response->status === 'error') {
-                throw new \Magento\Framework\Exception\LocalizedException($response->error);
+                throw new \Magento\Framework\Exception\LocalizedException(__($response->error));
             }
         }
     }


### PR DESCRIPTION
Previously could throw a fatal error if credit request failed
