### PR TITLE
Feature/widget

### DIFF
--- a/Block/Product/View/Widget.php
+++ b/Block/Product/View/Widget.php
@@ -7,6 +7,10 @@ class Widget extends \Magento\Catalog\Block\Product\AbstractProduct
     private $helper;
     private $catHelper;
 
+    const ALL_PRODUCTS = 'products_all';
+    const SELECTED_PRODUCTS = 'products_selected';
+    const THRESHOLD_PRODUCTS = 'products_price_threshold';
+
     public function __construct(
         \Divido\DividoFinancing\Helper\Data $helper,
         \Magento\Catalog\Block\Product\Context $context,
@@ -55,5 +59,32 @@ class Widget extends \Magento\Catalog\Block\Product\AbstractProduct
         }
         return $output;
     }
-
+    
+    public function showWidget(){
+        $threshold = $this->getThreshold();
+        if($threshold === false || $threshold < $this->getAmount()){
+            return false;
+        }else return true;
+    }
+    
+    public function getThreshold(){
+        $selection = $this->helper->getProductSelection();
+        return 12;
+        
+        switch($selection){
+            case self::ALL_PRODUCTS:
+                $threshold = 0;
+                break;
+            case self::SELECTED_PRODUCTS:
+                $product = $this->getProduct();
+                $plans = $this->helper->getLocalPlans($product->getId());
+                $threshold = (count($plans)>0) ? true : false;
+                break;
+            case self::THRESHOLD_PRODUCTS:
+                $threshold = (empty($this->helper->getPriceThreshold())) ? 0 : $this->helper->getPriceThreshold();
+                break;
+        }
+        
+        return $threshold;
+    }
 }

--- a/Block/Widget/BlockWidget.php
+++ b/Block/Widget/BlockWidget.php
@@ -1,0 +1,26 @@
+<?php
+namespace Divido\DividoFinancing\Block\Widget;
+
+use Magento\Framework\View\Element\Template;
+use Magento\Widget\Block\BlockInterface;
+
+class BlockWidget extends Template implements BlockInterface{
+
+    private $helper;
+    protected $_template = "widget/blockwidget.phtml";
+
+    public function __construct(
+        \Divido\DividoFinancing\Helper\Data $helper,
+        \Magento\Catalog\Block\Product\Context $context,
+        array $data = []
+    ) {
+        $this->helper = $helper;
+        parent::__construct($context, $data);
+    }
+
+    public function showable(){
+        if(!empty($this->helper->getApiKey()))
+            return true;
+        else return false;
+    }
+}

--- a/Block/Widget/PopupWidget.php
+++ b/Block/Widget/PopupWidget.php
@@ -1,0 +1,26 @@
+<?php
+namespace Divido\DividoFinancing\Block\Widget;
+
+use Magento\Framework\View\Element\Template;
+use Magento\Widget\Block\BlockInterface;
+
+class PopupWidget extends Template implements BlockInterface{
+    
+    private $helper;
+    protected $_template = "widget/popupwidget.phtml";
+
+    public function __construct(
+        \Divido\DividoFinancing\Helper\Data $helper,
+        \Magento\Catalog\Block\Product\Context $context,
+        array $data = []
+    ) {
+        $this->helper    = $helper;
+        parent::__construct($context, $data);
+    }
+
+    public function showable(){
+        if(!empty($this->helper->getApiKey()))
+            return true;
+        else return false;
+    }
+}

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -84,7 +84,36 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         
         return $prefix;
     }
+    
+    public function getProductSelection(){
+        $selection= $this->config->getValue(
+            'payment/divido_financing/product_selection',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+        
+        return $selection;
+    }
 
+    public function getPriceThreshold()
+    {
+        $threshold = $this->config->getValue(
+            'payment/divido_financing/price_threshold',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+        
+        return $threshold;
+    }
+
+    public function getActive()
+    {
+        $active = $this->config->getValue(
+            'payment/divido_financing/active',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+        
+        return $active;
+    }
+    
     public function getAllPlans()
     {
         $apiKey = $this->config->getValue(
@@ -192,10 +221,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function getLocalPlans($productId)
     {
-        $isActive = $this->config->getValue(
-            'payment/divido_financing/active',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-        );
+        $isActive = $this->getActive();
         if (! $isActive) {
             return[];
         }

--- a/README.md
+++ b/README.md
@@ -40,3 +40,28 @@ That should be it to get going with Divido as a checkout option.
 | Minimum cart amount | Under this amount, Divido is not available as a checkout option |
 | Product selection | Decide what products are available on finance |
 | Displayed plans | Decide what plans are globally available |
+
+## Content Page Widgets
+The Divido Extension also includes two widgets which can be inserted into the custom pages on your site. These widgets
+allow you to show the various options available to potential customers by either setting a static amount in the plugin's
+configuration, or by showing a text box that would allow the customer to enter an amount and instantly receive the details of their
+payment plan on that basis.
+
+The steps to implement this feature are explained below:
+
+1. Click on `Content` and then `Pages` in the submenu in your administration panel.
+2. Click on `Select` and then `Edit` in the submenu in the row corresponding to the page you wish to add the widget, or alternatively
+click the `Add New Page` button if you'd like the widget to feature on a new page.
+3. Click on the down arrow adjacent to the `Content` header to expand that section, then place the cursor where you would like the 
+widget to appear in the text editor and select the `Insert Widget` icon at the top left area of the editor.
+4. Select either *Divido Block Widget* or *Divido Popup Widget* from the `Widget Type` selection list
+5. Enter a default amount that the widget will calculate within the `Default Amount` widget option
+6. Choose to either show a text box, allowing customers to enter an amount which will dynamically calculate their potential plan, or
+hide this option by selecting No in the `Show text box?` widget option
+7. Click on the Insert Widget button at the bottom right
+8. Click on the `Save Page` button on the top right.
+
+Providing you have an API key inserted in your Setup (see above) the widget should now be displaying in the page you have edited/created.
+
+Please note that the Divido Widgets will stretch to 100% of the width of its container, so you may wish to enclose the widget within a
+`table column` or `div` if you would like to inhibit the width.

--- a/etc/widget.xml
+++ b/etc/widget.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<widgets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Widget:etc/widget.xsd">
+    <widget class="Divido\DividoFinancing\Block\Widget\BlockWidget" id="divido_dividofinancing_staticwidget">
+        <label>Divido Block Widget</label>
+        <description>The block version of our widget, displaying a list of your plans that dynamically 
+        updates based on the amount entered into the text box situated above it.</description>
+        <parameters>
+            <parameter name="defaultAmount" sort_order="10" visible="true" xsi:type="text" value="1000">
+                <label>Default Amount</label>
+            </parameter>
+            <parameter name="showInput" sort_order="11" visible="true" xsi:type="select" source_model="Magento\Config\Model\Config\Source\Yesno" >
+                <label>Show text box?</label>
+            </parameter>
+        </parameters>
+    </widget>
+    <widget class="Divido\DividoFinancing\Block\Widget\PopupWidget" id="divido_dividofinancing_popupwidget">
+        <label>Divido Popup Widget</label>
+        <description>The popup version of our widget, displaying a link with a brief summary of your plans that dynamically 
+        updates based on the amount entered into the text box situated above it. The link can be clicked on to view further 
+        information.</description>
+        <parameters>
+            <parameter name="defaultAmount" sort_order="10" visible="true" xsi:type="text" value="1000" >
+                <label>Default Amount</label>
+            </parameter>
+            <parameter name="showInput" sort_order="11" visible="true" xsi:type="select" source_model="Magento\Config\Model\Config\Source\Yesno" >
+                <label>Show text box?</label>
+            </parameter>
+        </parameters>
+    </widget>
+</widgets>

--- a/view/adminhtml/templates/order/view/custom.phtml
+++ b/view/adminhtml/templates/order/view/custom.phtml
@@ -3,7 +3,7 @@
 <?php if ($dividoInfo): ?>
 <div style="margin-top: 1rem; display: table; border-spacing: 1rem 0.5rem;">
     <div style="display: table-row;">
-        <div style="display: tasble-cell;">
+        <div style="display: table-cell;">
             <strong><?php echo __('Proposal ID') ?></strong> 
         </div>
         <div style="display: table-cell;">
@@ -11,7 +11,7 @@
         </div>
     </div>
     <div style="display: table-row;">
-        <div style="display: tasble-cell;">
+        <div style="display: table-cell;">
             <strong><?php echo __('Application ID') ?></strong>
         </div>
         <div style="display: table-cell;">
@@ -20,7 +20,7 @@
     </div>
 
     <div style="display: table-row;">
-        <div style="display: tasble-cell;">
+        <div style="display: table-cell;">
             <strong><?php echo __('Deposit amount') ?></strong>
         </div>
         <div style="display: table-cell;">

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0"?>
 <body>
-    <referenceBlock name="content">
-        <block template="head.phtml"
-            class="Divido\DividoFinancing\Block\Head"
-            name="divido_dividofinancing_block_head" />
-    </referenceBlock>
     <referenceContainer name="product.info.main">
         <block class="Divido\DividoFinancing\Block\Product\View\Widget"
             name="product.view.divido"

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -10,11 +10,6 @@
         <css src="Divido_DividoFinancing::divido-standard.css"/>
     </head>
     <body>
-        <referenceBlock name="content">
-            <block template="head.phtml"
-                class="Divido\DividoFinancing\Block\Head"
-                name="divido_dividofinancing_block_head" />
-        </referenceBlock>
         <referenceBlock name="checkout.root">
             <arguments>
                 <argument name="jsLayout" xsi:type="array">

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<body>
+    <referenceBlock name="content">
+        <block template="head.phtml"
+            class="Divido\DividoFinancing\Block\Head"
+            name="divido_dividofinancing_block_head" />
+    </referenceBlock>
+</body>

--- a/view/frontend/templates/product/view/widget.phtml
+++ b/view/frontend/templates/product/view/widget.phtml
@@ -1,7 +1,9 @@
 <?php /* @var $block \Divido\DividoFinancing\Block\Product\View\Extra */?>
-<?php if ($plans = $block->getProductPlans()): ?>
-  <div data-divido-widget data-divido-plans="<?php echo $plans; ?>" data-divido-amount="<?php echo $block->getAmount(); ?>" data-divido-mode="popup"
+  <div id='dividoWidget' 
+    data-divido-widget 
+    data-divido-plans="<?php echo $block->getProductPlans(); ?>"
+    data-divido-amount="<?php echo $block->getAmount(); ?>" 
+    data-divido-mode="popup"
   <?php echo $block->getPreOrSuffix('suffix'); ?>
   <?php echo $block->getPreOrSuffix('prefix'); ?>
   ></div>
-<?php endif; ?>

--- a/view/frontend/templates/widget/blockwidget.phtml
+++ b/view/frontend/templates/widget/blockwidget.phtml
@@ -1,0 +1,36 @@
+<?php /* @var $block \Divido\DividoFinancing\Block\Widget\BlockWidget */
+if($block->showable()):
+?>
+<input
+    type="<?php echo ($block->getData("showInput") == 1) ? "number" : "hidden"  ?>"
+    id='dividoAmountInput'
+    value="<?php echo $block->getData("defaultAmount"); ?>" 
+    min="250" 
+    max="25000" 
+    placeholder="Enter amount "
+    style="border-radius: 4px; padding: 4px; margin: 4px 0"
+/>
+<div id="dividoCalcWidget"
+    data-divido-widget
+    data-divido-title-logo
+    data-divido-amount="<?php echo ($block->getData("defaultAmount")) ? $block->getData("defaultAmount") : 2000; ?>"
+    data-divido-apply="true"
+    data-divido-plans
+    data-divido-logo 
+    data-divido-mode
+    >
+</div>
+                                        
+<script>
+document.getElementById('dividoAmountInput').addEventListener('keyup',function(event){
+    let amount = event.target.value;
+    let widget = document.getElementById('dividoCalcWidget');
+    if(amount >= 250 && amount <= 25000){
+        widget.setAttribute('data-divido-amount',amount);
+        widget.style.display = "";
+    }else{
+        widget.style.display = "none";
+    }
+});
+</script>
+<?php endif; ?>

--- a/view/frontend/templates/widget/popupwidget.phtml
+++ b/view/frontend/templates/widget/popupwidget.phtml
@@ -1,0 +1,36 @@
+<?php /* @var $block \Divido\DividoFinancing\Block\Widget\PopupWidget */
+if($block->showable()):
+?>
+<input
+    type="<?php echo ($block->getData("showInput") == 1) ? "number" : "hidden"  ?>"
+    id='dividoAmountInput'
+    value="<?php echo $block->getData("defaultAmount"); ?>" 
+    min="250" 
+    max="25000" 
+    placeholder="Enter amount "
+    style="border-radius: 4px; padding: 4px; margin: 4px 0"
+/>
+<div id="dividoCalcWidget"
+    data-divido-widget
+    data-divido-title-logo
+    data-divido-amount="<?php echo ($block->getData("defaultAmount")) ? $block->getData("defaultAmount") : 2000; ?>"
+    data-divido-apply="true"
+    data-divido-plans
+    data-divido-logo 
+    data-divido-mode="popup"
+    >
+</div>
+                                        
+<script>
+document.getElementById('dividoAmountInput').addEventListener('keyup',function(event){
+    let amount = event.target.value;
+    let widget = document.getElementById('dividoCalcWidget');
+    if(amount >= 250 && amount <= 25000){
+        widget.setAttribute('data-divido-amount',amount);
+        widget.style.display = "";
+    }else{
+        widget.style.display = "none";
+    }
+});
+</script>
+<?php endif; ?>


### PR DESCRIPTION
Added two widgets to the component so that admins can add either the popup or block widget to their custom pages (with or without a textbox)

Also:
- **Altered the Helper class so that getting the *Enabled* config is its own method that `getLocalPlans` uses instead of just looking it up**
- **Changed the structure for the xml files so that the head always includes a  request for the Divido Javascript throughout the site**
- Updated the README with a little walkthrough for adding widgets
- Fixed a typo in view/adminhtml/templates/order/view/custom.phtml